### PR TITLE
Alternate approach to press page

### DIFF
--- a/src/pages/Press.js
+++ b/src/pages/Press.js
@@ -7,60 +7,49 @@ import {
   MenuWrapper,
   Photography,
 } from "./PressStyle";
-import "./press.css"
+import "./press.css";
 
 const Press = () => {
-  const [exhibitionOff, setExhibition] = useState(false);
-  const [photographyOff, setPhotography] = useState(false);
-  const [featuresOff, setFeatures] = useState(false);
+  const [sectionShowing, setSectionShowing] = useState("");
 
-  const handleExhibit = () => {
-    setExhibition(!exhibitionOff);
-    setPhotography(false);
-    setFeatures(false);
-  };
-
-  const handlePhotography = () => {
-    setPhotography(!photographyOff);
-    setExhibition(false);
-    setFeatures(false);
-  };
-
-  const handleFeatures = () => {
-    setFeatures(!featuresOff);
-    setExhibition(false);
-    setPhotography(false);
+  const handleMenuClick = (section) => {
+    if (sectionShowing === section) {
+      setSectionShowing("");
+    } else {
+      setSectionShowing(section);
+    }
   };
 
   return (
     <div>
       <Header />
-      <Content>
-        <MenuWrapper>
+      <Content
+        style={{ display: "flex", flexDirection: "row", alignItems: "center" }}
+      >
+        <MenuWrapper style={{ flexGrow: 0 }}>
           <Exhibitions
-            onClick={() => {
-              handleExhibit();
-            }} className={exhibitionOff ? `on-exhib` : `off-exhib`}
+            onClick={() => handleMenuClick("exhibitions")}
+            className={
+              sectionShowing === "exhibitions" ? "on-exhib" : "off-exhib"
+            }
           >
             Exhibitions
           </Exhibitions>
-
           <Photography
-            onClick={() => {
-              handlePhotography();
-            }} className=""
+            onClick={() => handleMenuClick("photography")}
+            className=""
           >
             Photography
           </Photography>
-
-          <Features
-            onClick={() => {
-              handleFeatures();
-            }} className=""
-          >
+          <Features onClick={() => handleMenuClick("features")} className="">
             Features
           </Features>
         </MenuWrapper>
+        <div style={{ marginLeft: "1rem" }}>
+          {sectionShowing === "exhibitions" && <div>Exhibition section</div>}
+          {sectionShowing === "photography" && <div>Photography section</div>}
+          {sectionShowing === "features" && <div>Features section</div>}
+        </div>
       </Content>
     </div>
   );

--- a/src/pages/press.css
+++ b/src/pages/press.css
@@ -1,8 +1,8 @@
-.on-exhib{
-    color: red;
-    font-size: 100px;
+.on-exhib {
+  color: red;
+  font-size: 100px;
 }
 
-.off-exhib{
-    color: 414141;
+.off-exhib {
+  color: #414141;
 }


### PR DESCRIPTION
I thought it might clean things up to save the section that should be showing instead of having a different boolean for each. Right now this allows toggling a section on and off, but it could be even simpler if you wanted to start with a section showing and switch it when a different section's link is clicked.