### PR TITLE
Pin menu to the bottom of the page

### DIFF
--- a/src/components/ButtonStyle.js
+++ b/src/components/ButtonStyle.js
@@ -1,18 +1,12 @@
 import styled from "styled-components";
 
-
 export const Wrapper = styled.div`
-  bottom: 0;
-  max-width: 100vw;
-  height: auto;
-  margin-top: 39%;
-  @media (max-width: 800px) {
-    margin-top: 115%;
-  }
+  position: fixed;
+  width: 100vw;
+  bottom: 15px;
 `;
 
 export const Content = styled.div`
-  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,9 +14,6 @@ export const Content = styled.div`
 `;
 
 export const ButtonMenu = styled.button`
-  margin-bottom: 2%;
-  bottom: 0;
-  position: fixed;
   height: 1rem;
   width: 1rem;
   border-radius: 100%;


### PR DESCRIPTION
The changes here fix the menu to the bottom. I'm still not if sure that's what you were going for or not. If not, let me know and we can discuss some other fixes. 

A few other thoughts:

1. The images in the `personal` directory of the `pressdata` are huge. It's almost a half gig which slows down pushes and pulls. If the images being used on site, you'll probably want to scale them down to something substantially smaller. Otherwise, it's going to take things a while to load (especially on mobile).
2. The default value for `width` and `height` in CSS is `auto`. You can delete every `width: auto` and `height: auto` as they aren't doing anything. Similarly, there's a lot of `min-width: 100vw`. The default width for elements that are `display: block` (e.g. `<div>`s) is 100% which is essentially the same. So, I think you can safely remove those as well.
3. I'd go through and delete everything that's commented out and remove all unused imports. You can always look at previous commits in GitHub if you need to remember what you had before. Similarly, I'd go through and remove all unused imports. That will make it easier to focus on the things that are being used.
4. It's usually "best practice" to add the `build` directory to your `.gitignore` file. It'll get created when the project is run and helps save on bandwidth/repository size.
5. There are a bunch of places where the CSS is kind of fighting itself. For example, in `CardStyle.js`,  `Content` has 
```css
  min-width: 100vw;
  margin: 0 auto;
```
`margin: 0 auto;` is usually used to center an element that's not full width, but in this case the element is already going to be at least as wide as the whole viewport, so there's nothing to center.

Lower in the file there's this media query for the ImgCard
```css
  @media (max-width: 800px) {
    min-height: 400px;
    max-height: 400px;
    object-fit: contain;
    width: 68%;
  }
```
Setting width as a percentage and height as a fixed value you may see the images getting stretched or squished depending on the width/height of the viewport. Also, if you're setting `min-height` and `max-height` to the same value, you can just set `height` instead as that's essentially what you've done.

6. It's a good idea to stick to one approach for styling. It's already a little tricky to figure out whether something was styled in an imported css file or with a styled component and that will only get worse with more complex sites.
7. I'd avoid re-using names for components. Having a `Wrapper` in both `ButtonStyle.js` and `CardStyle.js` and them having different properties was a bit confusing. Generally, you'd just have one generic `Wrapper` that could be used in multiple places or you'd create a `ButtonWrapper` and a `CardWrapper` if the components are going to be different.
8. Simliar to the above, it might be worth renaming some of the files and exports. For example, `Button.js` isn't actually a button. It might not be a big deal right now, but if you put this project down for six months or a year, it's going to be much harder coming back and trying to figure things out if  names don't match up with what components are/do.